### PR TITLE
[histórico de pedidos] Aumentando o tempo de um teste para melhorar a visualização

### DIFF
--- a/test-acceptance/stepdefinitions/historico-pedidos.ts
+++ b/test-acceptance/stepdefinitions/historico-pedidos.ts
@@ -101,7 +101,8 @@ defineSupportCode(function({Given, When, Then}) {
 
     Then(/^Eu vejo uma mensagem dizendo que "(.*)"$/, async(message) => {
         await browser.wait(protractor.ExpectedConditions.alertIsPresent(), 5000);
-        var alert = browser.switchTo().alert()
+        var alert = browser.switchTo().alert();
+        await new Promise(resolve => setTimeout(resolve, 500));
         expect(Promise.resolve(alert.getText())).to.eventually.equal(message);
         await alert.accept();
     });


### PR DESCRIPTION
Adição de tempo entre o aparecimento do alerta e a aceitação dele nos testes do histórico para que o usuário vejo o alerta